### PR TITLE
Generic query issues.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.1
+
+- Fixed issue with generic query where connection was being closed before query results were returned.
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## v0.1.0
 
 Initial Revision

--- a/actions/generic_query.py
+++ b/actions/generic_query.py
@@ -18,17 +18,19 @@ class SQLQueryAction(BaseAction):
 
         query = self.get_del_arg('query', kwargs_dict)
 
+        return_result = None
         with self.db_connection(kwargs_dict) as conn:
             # Execute the query
             query_result = conn.execute(query)
 
-        return_result = {'affected_rows': query_result.rowcount}
-        if query_result.returns_rows:
-            return_result = []
-            all_results = query_result.fetchall()
-            for row in all_results:
-                # Rows are returned as tuples with keys.
-                # Convert that to a dictionary for return
-                return_result.append(self.row_to_dict(row))
+            # We need to execute these commands while connection is still open.
+            return_result = {'affected_rows': query_result.rowcount}
+            if query_result.returns_rows:
+                return_result = []
+                all_results = query_result.fetchall()
+                for row in all_results:
+                    # Rows are returned as tuples with keys.
+                    # Convert that to a dictionary for return
+                    return_result.append(self.row_to_dict(row))
 
         return return_result

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,10 +2,10 @@
 ref: sql
 name: sql
 description: StackStorm Integration Pack for SQL Databases (Postgres, MySQL, etc)
-keywords: 
+keywords:
     - Postgres
-    -  MySQL
-    -  MsSQL
-version: 0.1.0
+    - MySQL
+    - MsSQL
+version: 0.1.1
 author: Encore Technologies
 email: code@encore.tech


### PR DESCRIPTION
Moved code to print rows to be executed while connection is still open because SQL alchemy does not return all information when the query is executed. We still need the connection open when checking the rows and fetching them.

Before:
```
# st2 run sql.query host="test.domain.tld" username='SA' password='password' port=1433 drivername='mssql' database="testdb" query="SELECT MenuName, Expires FROM testtb WHERE MenuName='test'"
.
id: 5db5035449b3d2b0f70d9cd8
status: succeeded
parameters: 
  database: testdb
  drivername: mssql
  host: test.domain.tld
  password: '********'
  port: 1433
  query: SELECT MenuName, Expires FROM testtb WHERE MenuName='test'
  username: SA
result: 
  exit_code: 0
  result: []
  stderr: ''
  stdout: ''
```
After:
```
# st2 run sql.query host="test.domain.tld" username='SA' password='password' port=1433 drivername='mssql' database="testdb" query="SELECT MenuName, Expires FROM testtb WHERE MenuName='test'"
.
id: 5db5035449b3d2b0f70d9cd8
status: succeeded
parameters: 
  database: testdb
  drivername: mssql
  host: test.domain.tld
  password: '********'
  port: 1433
  query: SELECT MenuName, Expires FROM testtb WHERE MenuName='test'
  username: SA
result: 
  exit_code: 0
  result:
  - Expires: '9999-12-31T00:00:00'
    MenuName: test
  stderr: ''
  stdout: ''
```